### PR TITLE
Changing the path to be a clip for a changing background image

### DIFF
--- a/src/components/ComingSoon.scss
+++ b/src/components/ComingSoon.scss
@@ -14,37 +14,35 @@ $textColor: #cf33ff;
 
     &--cool {
         margin: 2rem auto;
-        background-color: #33ffa3;
-        // background-image: url("https://avatars1.githubusercontent.com/u/33829929?s=460&v=4");
-        // background-repeat: no-repeat;
+        background-color: transparent;
+        background-image: url("https://cdn.discordapp.com/attachments/477136006361907210/655751431466385428/image0.jpg");
+        background-size: contain;
+        background-repeat: no-repeat;
+        background-position: center;
 
         height: 75vh;
         width: 90vw;
 
         // animation properties
-        clip-path: polygon(50% 0%, 0 40%, 100% 100%);
-        transform: rotateX(0deg);
-        transform: rotateY(0deg);
-
+        clip-path: polygon(50% 0%, 0 40%, 100% 100%, 25% 33%);
+  
         animation: salmon 8s infinite;
-        
     }
     @keyframes salmon {
         0% {
-            clip-path: polygon(10% 0%, 0 90%, 100% 100%);
+            clip-path: polygon(0 0, 0 0, 100% 100%, 100% 100%)
         }
-        33% {
-            clip-path: polygon(90% 0%, 0 10%, 50% 40%);
-            transform: rotateX(160deg);
-            transform: rotateY(160deg);
+        25% {
+            clip-path: polygon(0 0, 100% 0, 0 100%, 100% 100%)
         }
-        66% {
-            clip-path: polygon(30% 0%, 0 70%, 60% 35%);
-            transform: rotateX(10deg);
-            transform: rotateY(10deg);
+        50% {
+            clip-path: polygon(0 0, 0 100%, 100% 0, 100% 100%);
+        }
+        75% {
+            clip-path: polygon(0 0, 0 100%, 100% 100%, 100% 0);
         }
         100% {
-            clip-path: polygon(10% 0%, 0 90%, 100% 100%);
+            clip-path: polygon(0 0, 100% 100%, 100% 100%, 0% 0%);
         }
     }
 

--- a/src/components/ComingSoon.tsx
+++ b/src/components/ComingSoon.tsx
@@ -24,12 +24,19 @@ const loadingMessages = [
     "Seeking discomfort",
     "Saying yes to waiting a bit longer for more website content",
     "Making up some excuse for why this doesn't finish loading",
-]
+];
+
+const imageUrls = [
+    "https://cdn.discordapp.com/attachments/477136006361907210/655751431466385428/image0.jpg",
+    "https://cdn.discordapp.com/attachments/477136006361907210/646003485430513695/image1.png",
+    "https://cdn.discordapp.com/attachments/477136006361907210/645305704126873632/IMG-20191115-WA0088.jpg",
+    "https://cdn.discordapp.com/attachments/477136006361907210/643030622830592030/20191109_234349.jpg",
+];
 
 let loadingMessageInterval: number = -1;
 
 const ComingSoon = () => {
-    const [loadingMessage, setLoadingMessage] = useState('Loading website content')
+    const [loadingMessage, setLoadingMessage] = useState('Loading website content');
 
     useEffect(() => {
         loadingMessageInterval = window.setInterval(() => {
@@ -38,8 +45,11 @@ const ComingSoon = () => {
 
         // Cleanup of effect
         return () => clearInterval(loadingMessageInterval);
-    })
+    });
 
+    const [imageUrl, setImageUrl] = useState('https://cdn.discordapp.com/attachments/477136006361907210/655751431466385428/image0.jpg');
+    const url = `url(${imageUrl})`;
+    
     return (
         <div className="comingSoon">
             <header>
@@ -58,7 +68,7 @@ const ComingSoon = () => {
                         This website is still under construction. Check back later.
                     </p>
                 </div>
-                <div className="comingSoon--cool"></div>
+                <div className="comingSoon--cool" style={{backgroundImage: url}} onAnimationIteration={() => setImageUrl(imageUrls[getRandomInt(0, imageUrls.length)])}></div>
             </section>
         </div>
     )


### PR DESCRIPTION
The animated shape now acts as a clip for a random (of currently four) images of meetups.
The animation cycle is from an hourglass shape, to a 90° flipped hourglass, to the full image, to a clear screen:

![hourglass](https://user-images.githubusercontent.com/26303198/71535364-d1d20a00-2905-11ea-8f9c-fa25c88972c6.png)
![90° hourglass](https://user-images.githubusercontent.com/26303198/71535369-e0b8bc80-2905-11ea-8482-3b82a6741ab5.png)
![full image](https://user-images.githubusercontent.com/26303198/71535391-0e9e0100-2906-11ea-9901-5ba139627454.png)
![transition to clear screen](https://user-images.githubusercontent.com/26303198/71535401-27a6b200-2906-11ea-998b-7e23351467c7.png)

After the animation cycle finished, a random image is selected again and set as background image for the animation.

Example of the screen on mobile mid animation:

![mobile](https://user-images.githubusercontent.com/26303198/71535439-705e6b00-2906-11ea-9955-c385f8c61c94.png)

The images and animations do not seem to overshoot the display.