### PR TITLE
fix: free spots in photowall

### DIFF
--- a/src/pages/photowall/PhotoWall.tsx
+++ b/src/pages/photowall/PhotoWall.tsx
@@ -155,6 +155,7 @@ const getNextBuiltLayout = async (
   }
 
   const availableOrientationLayouts = availableLayouts
+    .filter(({ props }) => props.totalImages === pickedImages.length)
     .filter(({ props }) => props.horizontalImages <= pickedHorizontal)
     .filter(({ props }) => props.verticalImages <= pickedVertical);
 


### PR DESCRIPTION
There was an issue that could cause free spots in the photowall to occur
in rare cases. This can happen if the picked images don't fit the
layout's requirements and a layout with more free spots is chosen.

Layouts are now additionally filtered for total images required to match
the amount of picked images to fix this.