### PR TITLE
Chore/refactor button css use padding

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -70,7 +70,7 @@ img {
   }
 }
 
-.button {
+button, .button {
   @extend .centered-content;
 
   padding: 16px 40px;

--- a/src/pages/photowall/PhotoWall.tsx
+++ b/src/pages/photowall/PhotoWall.tsx
@@ -36,7 +36,7 @@ const InitialContent: React.FC<{ onButtonClick: () => void }> = ({
         event on our photowall. The more people can see it, the more people will
         get involved next time. Make the FOMO be real!
       </div>
-      <button className="button" onClick={onButtonClick}>
+      <button onClick={onButtonClick}>
         BE PART OF THE STORY
       </button>
     </div>


### PR DESCRIPTION
button detail:
before:
![image](https://user-images.githubusercontent.com/5422571/79582490-17406000-80cc-11ea-96f2-825cd2831132.png)
after:
![image](https://user-images.githubusercontent.com/5422571/79582533-2e7f4d80-80cc-11ea-99b8-e9841208f0d9.png)

button used in a context:
before:
![image](https://user-images.githubusercontent.com/5422571/79582506-1dced780-80cc-11ea-93de-7d61a95c7807.png)
after:
![image](https://user-images.githubusercontent.com/5422571/79582579-4060f080-80cc-11ea-8e0d-61205c89e534.png)

Reason for change:
Having to set a custom width/height for a button is tedious and not responsive. If we add padding to the buttons, we get the whitespace pretty much for free when creating buttons.

Also makes all buttons use  the button styling by default, without having to specify `<button class="button" />`.