### PR TITLE
attempted fix for the redirect issue

### DIFF
--- a/src/components/NavHooks/SavePage.ts
+++ b/src/components/NavHooks/SavePage.ts
@@ -2,18 +2,17 @@ import { FC, useEffect } from "react";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 
 const savePage = (currentPage: string) => {
-  localStorage.setItem("current_page", currentPage);
+  if (!currentPage.includes("auth"))
+    localStorage.setItem("current_page", currentPage);
 }
 
-// Ok hear me out...
-// history listen fires when the route is changing but with the old location
-// Which is exactly what we want because the redirect moves over one step on the route
-// /auth/discord
-// So the page before that route is the one the user was active one when clicking the button
-// so the one that we want to go back to which is why this work
+// Saves the current path in localstorage when the page is loaded or changed
+// Excluding auth routes
 const SavePage: FC<RouteComponentProps> = ({ history, location }) => {
+  savePage(location.pathname);
+
   useEffect(() => {
-    const unlisten = history.listen(() => savePage(location.pathname));
+    const unlisten = history.listen((newLocation) => savePage(newLocation.pathname));
     return () => unlisten();
   });
 


### PR DESCRIPTION
I suspect the issue to lie in a race condition happening on the auth/discord route where the process of writing to localStorage races the redirect moving away from the page.

In an attempt to solve this, the write to localStorage now happens on navigation to a page instead of navigation away from a page within the application (excluding auth routes).