### PR TITLE
chore: Import {firebase, date-fns} functions directly to tree shake better

### DIFF
--- a/src/pages/BuddyProject/buddyprojectFirebase.ts
+++ b/src/pages/BuddyProject/buddyprojectFirebase.ts
@@ -1,4 +1,7 @@
-import firebase from "firebase";
+import firebase from "firebase/app";
+
+// Imported for side effects; adding `firestore` to `firebase`.
+import "firebase/firestore";
 
 let _db: firebase.firestore.Firestore | null = null;
 

--- a/src/pages/MeetupDetails/MeetupDetails.tsx
+++ b/src/pages/MeetupDetails/MeetupDetails.tsx
@@ -7,7 +7,7 @@ import IMeetupProps from "../../types/Meetups";
 import "./MeetupDetails.scss";
 
 import { Link, RouteProps, RouteComponentProps } from "react-router-dom";
-import { format } from "date-fns";
+import format from "date-fns/format";
 import { IoIosPeople, IoMdCalendar } from "react-icons/io";
 
 const YES_THEORY_BLUE = "rgb(1, 102, 255)";

--- a/src/pages/meetups/Meetups.tsx
+++ b/src/pages/meetups/Meetups.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { format } from "date-fns";
+import format from "date-fns/format";
 
 import NavBar from "../../components/NavBar/NavBar";
 import Footer from "../../components/Footer/Footer";


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5422571/79846043-38e86280-83be-11ea-9536-367011a01ce5.png)

Graphics generated with `webpack-bundle-analyzer`.

Firebase seems like the main culprit along with the icon lib.

```
WARNING in asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
This can impact web performance.
Assets:
  1a7a39a5d4b8df35e47c90f901a8a0f9.png (1.33 MiB)
  85bd97faa3e2e6061fe98c3912967f08.png (741 KiB)
  e2eed95002185eb117ba94a0b85d53d2.png (245 KiB)
  7c125993ce902f803fcc6924e51c738a.png (445 KiB)
  vendors~main.js (1.17 MiB)

WARNING in entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (244 KiB). This can impact web performance.
Entrypoints:
  main (1.27 MiB)
      vendors~main.js
      main.js
```

Since firebase is only used for buddy project, it might be relevant to look into code splitting and only load it on demand.