### PR TITLE
feat: reduce bundlesize (gzipped) by almost half

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,27 +1,18 @@
 {
-    "compilerOptions": {
-        "jsx": "react",
-        "lib": [
-            "es6",
-            "dom"
-        ],
-        "rootDir": "src",
-        "module": "commonjs",
-        "target": "es5",
-        "sourceMap": true,
-        "moduleResolution": "node",
-        "noImplicitReturns": true,
-        "noImplicitThis": true,
-        "noImplicitAny": true,
-        "strictNullChecks": true,
-        "allowSyntheticDefaultImports": true
-    },
-    "include": [
-        "./src",
-        "./custom.d.ts"
-    ],
-    "exclude": [
-        "node_modules",
-        "build"
-    ]
+  "compilerOptions": {
+    "jsx": "react",
+    "lib": ["es6", "dom"],
+    "rootDir": "src",
+    "module": "es6",
+    "target": "es5",
+    "sourceMap": true,
+    "moduleResolution": "node",
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["./src", "./custom.d.ts"],
+  "exclude": ["node_modules", "build"]
 }


### PR DESCRIPTION
Changing tsconfig to not compile to common.js but es6 modules allows webpack to properly treeshake modules supporting it (looking at you react-icons).

Because it wasn't formatted to prettier's likings, this commit also reformats the file (sorry). The key change is from line 9 (old) to line 6 (new).

This change reduces the production bundle-size from 651.72KB gzipped to 335.9KB on the about-us page branch with two react-icons libraries being used.

Fixes #38 