### PR TITLE
Remove unused pages from mobile menu and get rid of keys error

### DIFF
--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -129,10 +129,7 @@ const NavBar: React.FC<{ fixed: boolean; classNames?: string }> = ({
   const userNav = pages
     .filter(({ available }) => available)
     .map((p) => pageToNavLink(p, true));
-    
-  const mobileNav = pages
-    .filter(({ available }) => available)
-    .map((p) => pageToNavLink(p, p.available));
+  const mobileNav = pages.map((p) => pageToNavLink(p, p.available));
 
   if (user) userNav.push(<CurrentUser key="current-user" />);
 


### PR DESCRIPTION
Noticed the mobile menu was still showing all the links 
and a key error